### PR TITLE
Configurable OIDC username

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ OIDC_CLIENT_SECRETS = '/path/to/client_secret.json'
 
 see the [flask_oidc manual client registration][flask_oidc_manual_config] docs for how to generate or write one.
 
+### OIDC Field configuration
+If you like to change the default OIDC field that will be used as a username, you can set the following env var in the shell you run your process:
+
+```bash
+export USERNAME_OIDC_FIELD='preferred_username'
+```
+
 Copyright © 2018 HM Government (Ministry of Justice Digital Services). See LICENSE.txt for further details.
 
 

--- a/fab_oidc/views.py
+++ b/fab_oidc/views.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 
 
 # Set the OIDC field that should be used as a username
-USERNAME_OIDC_FIELD = os.getenv('CONF_USERNAME_OIDC_FIELD' ,default='preferred_username')
+USERNAME_OIDC_FIELD = os.getenv('CONF_USERNAME_OIDC_FIELD', default='sub')
 
 class AuthOIDCView(AuthOIDView):
 

--- a/fab_oidc/views.py
+++ b/fab_oidc/views.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 
 
 # Set the OIDC field that should be used as a username
-USERNAME_OIDC_FIELD = os.getenv('CONF_USERNAME_OIDC_FIELD', default='sub')
+USERNAME_OIDC_FIELD = os.getenv('USERNAME_OIDC_FIELD', default='sub')
 
 class AuthOIDCView(AuthOIDView):
 

--- a/fab_oidc/views.py
+++ b/fab_oidc/views.py
@@ -1,9 +1,13 @@
+import os
 from flask import redirect, request
 from flask_appbuilder.security.views import AuthOIDView
 from flask_login import login_user
 from flask_admin import expose
 from urllib.parse import quote
 
+
+# Set the OIDC field that should be used as a username
+USERNAME_OIDC_FIELD = os.getenv('CONF_USERNAME_OIDC_FIELD' ,default='preferred_username')
 
 class AuthOIDCView(AuthOIDView):
 
@@ -19,11 +23,11 @@ class AuthOIDCView(AuthOIDView):
 
             if user is None:
                 info = oidc.user_getinfo(
-                    ['sub', 'name', 'email', 'nickname']
+                    [USERNAME_OIDC_FIELD, 'name', 'email', 'nickname']
                 )
 
                 user = sm.add_user(
-                    username=info.get('sub'),
+                    username=info.get(USERNAME_OIDC_FIELD),
                     first_name=info.get('nickname'),
                     last_name=info.get('name'),
                     email=info.get('email'),
@@ -66,14 +70,14 @@ class SupersetAuthOIDCView(AuthOIDView):
 
             if user is None:
                 info = oidc.user_getinfo(
-                    ['sub', 'given_name', 'family_name', 'email']
+                    [USERNAME_OIDC_FIELD, 'given_name', 'family_name', 'email']
                 )
 
                 # Superset requires `first_name` not to be NULL, so we use the
                 # `given_name` rather than `nickname`, which has higher
                 # probability for being NULL
                 user = sm.add_user(
-                    username=info.get('sub'),
+                    username=info.get(USERNAME_OIDC_FIELD),
                     first_name=info.get('given_name'),
                     last_name=info.get('family_name'),
                     email=info.get('email'),


### PR DESCRIPTION
We have a use case that required the `preferred_username` OIDC field to be used as username, instead of the current hardcoded `sub` field.

This PR aims to make the OIDC field used as username to be configurable with as default `sub`.