### PR TITLE
refactor: Superset view and configurable fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,15 @@ OIDC_CLIENT_SECRETS = '/path/to/client_secret.json'
 see the [flask_oidc manual client registration][flask_oidc_manual_config] docs for how to generate or write one.
 
 ### OIDC Field configuration
-If you like to change the default OIDC field that will be used as a username, you can set the following env var in the shell you run your process:
+
+If you like to change the default OIDC field that will be used as a username,
+first name and last name you can set the following env var in the shell you run
+your process:
 
 ```bash
 export USERNAME_OIDC_FIELD='preferred_username'
+export FIRST_NAME_OIDC_FIELD='given_name'
+export LAST_NAME_OIDC_FIELD='family_name'
 ```
 
 Copyright © 2018 HM Government (Ministry of Justice Digital Services). See LICENSE.txt for further details.
@@ -70,4 +75,4 @@ Copyright © 2018 HM Government (Ministry of Justice Digital Services). See LICE
 [flask_oidc_settings]: http://flask-oidc.readthedocs.io/en/latest/#settings-reference
 [flask_oidc_manual_config]: http://flask-oidc.readthedocs.io/en/latest/#manual-client-registration
 [Airflow]: https://airflow.apache.org/
-[Superset]: https://superset.incubator.apache.org/
+ [Superset]: https://superset.incubator.apache.org/

--- a/fab_oidc/security.py
+++ b/fab_oidc/security.py
@@ -1,9 +1,10 @@
 from flask_appbuilder.security.manager import AUTH_OID
 from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_oidc import OpenIDConnect
-from .views import AuthOIDCView, SupersetAuthOIDCView
+from .views import AuthOIDCView
 from logging import getLogger
 log = getLogger(__name__)
+
 
 class OIDCSecurityManagerMixin:
 
@@ -13,23 +14,25 @@ class OIDCSecurityManagerMixin:
             self.oid = OpenIDConnect(self.appbuilder.get_app)
             self.authoidview = AuthOIDCView
 
+
 class OIDCSecurityManager(OIDCSecurityManagerMixin, SecurityManager):
     pass
 
+
 try:
     from airflow.www_rbac.security import AirflowSecurityManager
-    class AirflowOIDCSecurityManager(OIDCSecurityManagerMixin, AirflowSecurityManager):
+
+    class AirflowOIDCSecurityManager(OIDCSecurityManagerMixin,
+                                     AirflowSecurityManager):
         pass
 except ImportError:
     log.debug('Airflow not installed')
 
 try:
     from superset.security import SupersetSecurityManager
-    class SupersetOIDCSecurityManager(SupersetSecurityManager):
-        def __init__(self, appbuilder):
-            super().__init__(appbuilder)
-            if self.auth_type == AUTH_OID:
-                self.oid = OpenIDConnect(self.appbuilder.get_app)
-                self.authoidview = SupersetAuthOIDCView
+
+    class SupersetOIDCSecurityManager(OIDCSecurityManagerMixin,
+                                      SupersetSecurityManager):
+        pass
 except ImportError:
     log.debug('Superset not installed')

--- a/fab_oidc/views.py
+++ b/fab_oidc/views.py
@@ -8,6 +8,11 @@ from urllib.parse import quote
 
 # Set the OIDC field that should be used as a username
 USERNAME_OIDC_FIELD = os.getenv('USERNAME_OIDC_FIELD', default='sub')
+FIRST_NAME_OIDC_FIELD = os.getenv('FIRST_NAME_OIDC_FIELD',
+                                  default='nickname')
+LAST_NAME_OIDC_FIELD = os.getenv('LAST_NAME_OIDC_FIELD',
+                                 default='name')
+
 
 class AuthOIDCView(AuthOIDView):
 
@@ -28,8 +33,8 @@ class AuthOIDCView(AuthOIDView):
 
                 user = sm.add_user(
                     username=info.get(USERNAME_OIDC_FIELD),
-                    first_name=info.get('nickname'),
-                    last_name=info.get('name'),
+                    first_name=info.get(FIRST_NAME_OIDC_FIELD),
+                    last_name=info.get(LAST_NAME_OIDC_FIELD),
                     email=info.get('email'),
                     role=sm.find_role(sm.auth_user_registration_role)
                 )
@@ -51,58 +56,6 @@ class AuthOIDCView(AuthOIDView):
 
         logout_uri = oidc.client_secrets.get(
             'issuer') + '/protocol/openid-connect/logout?redirect_uri='
-        if 'OIDC_LOGOUT_URI' in self.appbuilder.app.config:
-            logout_uri = self.appbuilder.app.config['OIDC_LOGOUT_URI']
-
-        return redirect(logout_uri + quote(redirect_url))
-
-class SupersetAuthOIDCView(AuthOIDView):
-
-    @expose('/login/', methods=['GET', 'POST'])
-    def login(self, flag=True):
-
-        sm = self.appbuilder.sm
-        oidc = sm.oid
-
-        @self.appbuilder.sm.oid.require_login
-        def handle_login():
-            user = sm.auth_user_oid(oidc.user_getfield('email'))
-
-            if user is None:
-                info = oidc.user_getinfo(
-                    [USERNAME_OIDC_FIELD, 'given_name', 'family_name', 'email']
-                )
-
-                # Superset requires `first_name` not to be NULL, so we use the
-                # `given_name` rather than `nickname`, which has higher
-                # probability for being NULL
-                user = sm.add_user(
-                    username=info.get(USERNAME_OIDC_FIELD),
-                    first_name=info.get('given_name'),
-                    last_name=info.get('family_name'),
-                    email=info.get('email'),
-                    role=sm.find_role(sm.auth_user_registration_role)
-                )
-
-            login_user(user, remember=False)
-            return redirect(self.appbuilder.get_url_for_index)
-
-        return handle_login()
-
-    @expose('/logout/', methods=['GET', 'POST'])
-    def logout(self):
-
-        oidc = self.appbuilder.sm.oid
-        id_token = oidc.get_access_token()
-
-        oidc.logout()
-        super(SupersetAuthOIDCView, self).logout()
-        redirect_url = request.url_root.strip(
-            '/') + self.appbuilder.get_url_for_login
-
-        issuer_uri = oidc.client_secrets.get('issuer')
-        logout_uri = f'{issuer_uri}/logout?id_token_hint={id_token}&redirect_uri='
-
         if 'OIDC_LOGOUT_URI' in self.appbuilder.app.config:
             logout_uri = self.appbuilder.app.config['OIDC_LOGOUT_URI']
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def desc():
 
 setup(
     name='fab_oidc',
-    version='0.0.7',
+    version='0.0.8',
     url='https://github.com/ministryofjustice/fab-oidc/',
     license='MIT',
     author='ministryofjustice',


### PR DESCRIPTION
Following #2, I believe it would be better to make pretty much all of the OIDC fields configurable, which also allows us to get rid of the specific Superset view and simplifies the whole module.

@r4vi let me know what you think, I am happy to change this is whatever way necessary :)

---------------------------------

* Remove unnecessary Superset-specific view

* Add config options for other OIDC fields (`first_name` and `last_name`).

Signed-off-by: mr.Shu <mr@shu.io>