### PR TITLE
Bugfix configurable oidc fields

### DIFF
--- a/fab_oidc/views.py
+++ b/fab_oidc/views.py
@@ -27,9 +27,12 @@ class AuthOIDCView(AuthOIDView):
             user = sm.auth_user_oid(oidc.user_getfield('email'))
 
             if user is None:
-                info = oidc.user_getinfo(
-                    [USERNAME_OIDC_FIELD, 'name', 'email', 'nickname']
-                )
+                info = oidc.user_getinfo([
+                    USERNAME_OIDC_FIELD,
+                    FIRST_NAME_OIDC_FIELD,
+                    LAST_NAME_OIDC_FIELD,
+                    'email',
+                ])
 
                 user = sm.add_user(
                     username=info.get(USERNAME_OIDC_FIELD),

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def desc():
 
 setup(
     name='fab_oidc',
-    version='0.0.8',
+    version='0.0.9',
     url='https://github.com/ministryofjustice/fab-oidc/',
     license='MIT',
     author='ministryofjustice',


### PR DESCRIPTION
Even though #3 introduced `FIRST_NAME_OIDC_FIELD` and `LAST_NAME_OIDC_FIELD`, it didn't update the call to `oid.user_getinfo()` which is still using hard-coded `nickname` and `name`.  
This pull request fixes the bug.