### PR TITLE
Added support synchronizing groups to roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,21 @@ see the [flask_oidc manual client registration][flask_oidc_manual_config] docs f
 ### OIDC Field configuration
 
 If you like to change the default OIDC field that will be used as a username,
-first name and last name you can set the following env var in the shell you run
+first name, last name and groups, you can set the following env var in the shell you run
 your process:
 
 ```bash
 export USERNAME_OIDC_FIELD='preferred_username'
 export FIRST_NAME_OIDC_FIELD='given_name'
 export LAST_NAME_OIDC_FIELD='family_name'
+export GROUPS_OIDC_FIELD='groups'
 ```
+
+### groups and roles syncronization
+
+If your IDP is configure to send back groups in ID tokens, you can syncronize your local roles with your IDP groups.
+To accomplish this, your local role names must match groups in your IDP. Exceptions are `AUTH_ROLE_ADMIN` and `AUTH_USER_REGISTRATION_ROLE` which are not synchronized.
+
 
 Copyright © 2018 HM Government (Ministry of Justice Digital Services). See LICENSE.txt for further details.
 

--- a/fab_oidc/views.py
+++ b/fab_oidc/views.py
@@ -71,19 +71,19 @@ class AuthOIDCView(AuthOIDView):
 
     def sync_roles(groups, user, sm):
         # sync OIDC groups to roles
+        updated = False
         for role in user.roles:
             if role.name not in groups and role.name not in [
                 sm.auth_role_admin,
                 sm.auth_user_registration_role]:
                 user.roles.remove(role)
-
-        if sm.get_session.is_modified(user):
-            sm.update_user(user)
+                updated = True
 
         for group in groups:
             role = sm.find_role(group)
             if role is not None:
                 user.roles.append(role)
+                updated = True
 
-        if sm.get_session.is_modified(user):
+        if updated:
             sm.update_user(user)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def desc():
 
 setup(
     name='fab_oidc',
-    version='0.0.9',
+    version='0.0.10',
     url='https://github.com/ministryofjustice/fab-oidc/',
     license='MIT',
     author='ministryofjustice',


### PR DESCRIPTION
Okta allows you to create a scope and claim type for groups. Using this combination, it is possible to pass groups to the client (i.e. Airflow) and use that to synchronize groups with local role.
This would make it easier to assign users to roles, if those roles are already defined in Okta.
To make this work, name of the groups in Okta and roles in the client should match.